### PR TITLE
Fix options types

### DIFF
--- a/__tests__/plugin.spec.ts
+++ b/__tests__/plugin.spec.ts
@@ -5,7 +5,7 @@ import fsp from 'fs/promises'
 import { build } from 'vite'
 import { compression } from '../src'
 import { len } from '../src/utils'
-import type { ViteCompressionPluginConfig } from '../src'
+import type { Algorithm, ViteCompressionPluginConfig } from '../src'
 import type { ZlibOptions } from 'zlib'
 
 const getId = () => Math.random().toString(32).slice(2, 10)
@@ -14,9 +14,12 @@ const sleep = (delay: number) => new Promise((resolve) => setTimeout(resolve, de
 
 const dist = path.join(__dirname, 'dist')
 
-async function mockBuild<T>(config?: ViteCompressionPluginConfig<T>, path?: string): Promise<string>
-async function mockBuild<T, K>(
-  config: [ViteCompressionPluginConfig<T>, ViteCompressionPluginConfig<K>],
+async function mockBuild<T = never, A extends Algorithm = never>(
+  config?: ViteCompressionPluginConfig<T, A>,
+  path?: string
+): Promise<string>
+async function mockBuild<T = never, A extends Algorithm = never, K = never, B extends Algorithm = never>(
+  config: [ViteCompressionPluginConfig<T, A>, ViteCompressionPluginConfig<K, B>],
   path?: string
 ): Promise<string>
 async function mockBuild(config: any = {}, dir = 'normal') {
@@ -146,7 +149,7 @@ test('filename', async (t) => {
 })
 
 test('multiple', async (t) => {
-  const id = await mockBuild<ZlibOptions, BrotliOptions>([
+  const id = await mockBuild<ZlibOptions, 'gzip', BrotliOptions, Exclude<Algorithm, 'gzip'>>([
     {
       algorithm: 'gzip',
       include: /\.(js)$/

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -16,12 +16,30 @@ interface BaseCompressionPluginOptions {
   deleteOriginalAssets?: boolean
 }
 
-type InternalCompressionPluginOptions<T> = {
-  algorithm?: Algorithm | AlgorithmFunction<T>
-  compressionOptions?: CompressionOptions<T>
+import type { ZlibOptions, BrotliOptions } from 'zlib'
+interface AlgorithmToZlib {
+  gzip: ZlibOptions
+  brotliCompress: BrotliOptions
+  deflate: ZlibOptions
+  deflateRaw: ZlibOptions
 }
 
-export type ViteCompressionPluginConfig<T> = BaseCompressionPluginOptions & InternalCompressionPluginOptions<T>
+type InternalCompressionPluginOptionsFunction<T> = {
+  algorithm?: AlgorithmFunction<T>
+  compressionOptions?: CompressionOptions<T>
+}
+type InternalCompressionPluginOptionsAlgorithm<A extends Algorithm> = {
+  algorithm?: A
+  compressionOptions?: AlgorithmToZlib[A]
+}
+
+export type ViteCompressionPluginConfigFunction<T> = BaseCompressionPluginOptions &
+  InternalCompressionPluginOptionsFunction<T>
+export type ViteCompressionPluginConfigAlgorithm<A extends Algorithm> = BaseCompressionPluginOptions &
+  InternalCompressionPluginOptionsAlgorithm<A>
+export type ViteCompressionPluginConfig<T, A extends Algorithm> =
+  | ViteCompressionPluginConfigFunction<T>
+  | ViteCompressionPluginConfigAlgorithm<A>
 
 interface BaseCompressMetaInfo {
   effect: boolean


### PR DESCRIPTION
# 修复插件配置选项类型提示

## 自定义泛型(优先)

- `algorithm`只能使用函数形式
- `compressionOptions`类型为自定义泛型

## 使用Algorithm类型时自动推断`compressionOptions`类型

```ts
type Algorithm = 'gzip' | 'brotliCompress' | 'deflate' | 'deflateRaw'
interface AlgorithmToZlib {
  gzip: ZlibOptions
  brotliCompress: BrotliOptions
  deflate: ZlibOptions
  deflateRaw: ZlibOptions
}
```

## 其他情况下相当于自定义`UserCompressionOptions`泛型